### PR TITLE
Filter by date within some lists of efa has been improved

### DIFF
--- a/de/nmichael/efa/data/types/DataTypeDate.java
+++ b/de/nmichael/efa/data/types/DataTypeDate.java
@@ -530,6 +530,26 @@ public class DataTypeDate implements Cloneable, Comparable<DataTypeDate> {
         }
         return EfaTypes.TEXT_UNKNOWN;
     }
+    
+    public String getWeekdayAsEfaType() {
+        switch (toCalendar().get(Calendar.DAY_OF_WEEK)) {
+	        case Calendar.MONDAY:
+	            return EfaTypes.TYPE_WEEKDAY_MONDAY;
+	        case Calendar.TUESDAY:
+	            return EfaTypes.TYPE_WEEKDAY_TUESDAY;
+	        case Calendar.WEDNESDAY:
+	            return EfaTypes.TYPE_WEEKDAY_WEDNESDAY;
+	        case Calendar.THURSDAY:
+	            return EfaTypes.TYPE_WEEKDAY_THURSDAY;
+	        case Calendar.FRIDAY:
+	            return EfaTypes.TYPE_WEEKDAY_FRIDAY;
+	        case Calendar.SATURDAY:
+	            return EfaTypes.TYPE_WEEKDAY_SATURDAY;
+	        case Calendar.SUNDAY:
+	            return EfaTypes.TYPE_WEEKDAY_SUNDAY;
+	    }
+        return EfaTypes.TEXT_UNKNOWN;	
+    }
 
     public static String[] makeDistanceUnitValueArray() {
         String[] units = new String[2];

--- a/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
@@ -1,0 +1,71 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.BoatDamageRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class BoatDamageItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public BoatDamageItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(BoatDamageRecord.REPORTDATE);
+		String theDateTo = theDataRecord.getAsString(BoatDamageRecord.FIXDATE);
+
+		if ((theDateFrom == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = null;
+
+			if ((theDateTo != null)) {
+				toDate = DataTypeDate.parseDate(theDateTo);
+				if ((fromDate.isSet() && toDate.isSet())) {
+
+					// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+					return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+				} else {
+					return false;
+				}
+			} else {
+				if (fromDate.isSet()) {
+					return (curDate.isAfterOrEqual(fromDate));
+				} else {
+					return false;
+				}
+			}
+
+		}
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
@@ -10,21 +10,36 @@
 
 package de.nmichael.efa.gui.dataedit;
 
-import de.nmichael.efa.*;
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.util.UUID;
+
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+
+import de.nmichael.efa.Daten;
 import de.nmichael.efa.core.config.AdminRecord;
-import de.nmichael.efa.core.items.*;
-import de.nmichael.efa.data.*;
-import de.nmichael.efa.data.storage.*;
+import de.nmichael.efa.core.items.IItemType;
+import de.nmichael.efa.core.items.ItemTypeBoolean;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeStringAutoComplete;
+import de.nmichael.efa.data.BoatDamageRecord;
+import de.nmichael.efa.data.BoatDamages;
+import de.nmichael.efa.data.BoatReservationRecord;
+import de.nmichael.efa.data.Boats;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
 import de.nmichael.efa.data.types.DataTypeDate;
 import de.nmichael.efa.data.types.DataTypeTime;
 import de.nmichael.efa.gui.SimpleInputDialog;
 import de.nmichael.efa.gui.util.AutoCompleteList;
-import de.nmichael.efa.util.*;
 import de.nmichael.efa.util.Dialog;
-import java.util.*;
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import de.nmichael.efa.util.International;
+import de.nmichael.efa.util.Logger;
 
 
 // @i18n complete
@@ -50,6 +65,66 @@ public class BoatDamageListDialog extends DataListDialog {
         iniValues(boatId);
     }
 
+    // Methode übernommen von DataListDialog - Ausnahme ist, dass wir hier einen
+    // expliziten BoatReservationItemTypeDataRecordTable setzen, damit man besser filtern kann.
+    protected void iniDialog() throws Exception {
+        mainPanel.setLayout(new BorderLayout());
+        
+        JPanel mainTablePanel = new JPanel();
+        mainTablePanel.setLayout(new BorderLayout());
+
+        if (filterFieldDescription != null) {
+            JLabel filterName = new JLabel();
+            filterName.setText(filterFieldDescription);
+            filterName.setHorizontalAlignment(SwingConstants.CENTER);
+            mainTablePanel.add(filterName, BorderLayout.NORTH);
+            mainTablePanel.setBorder(new EmptyBorder(10,0,0,0));
+        }
+
+        table = new BoatDamageItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+        table.setSorting(sortByColumn, sortAscending);
+        table.setFontSize(tableFontSize);
+        table.setMarkedCellColor(markedCellColor);
+        table.setMarkedCellBold(markedCellBold);
+        table.disableIntelligentColumnWidth(!intelligentColumnWidth);
+        if (minColumnWidth > 0) {
+            table.setMinColumnWidth(minColumnWidth);
+        }
+        if (minColumnWidths != null) {
+            table.setMinColumnWidths(minColumnWidths);
+        }
+        table.setButtonPanelPosition(buttonPanelPosition);
+        table.setFieldSize(600, 500);
+        table.setPadding(0, 0, 10, 0);
+        table.displayOnGui(this, mainTablePanel, BorderLayout.CENTER);
+
+        boolean hasEditAction = false;
+        for (int i=0; actionType != null && i < actionType.length; i++) {
+            if (actionType[i] == ItemTypeDataRecordTable.ACTION_EDIT) {
+                hasEditAction = true;
+            }
+        }
+        if (!hasEditAction) {
+            table.setDefaultActionForDoubleclick(-1);
+        }
+
+        iniControlPanel();
+        mainPanel.add(mainTablePanel, BorderLayout.CENTER);
+
+        setRequestFocus(table);
+        this.validate();
+        
+        table.setIsFilterSet(true);// in der Bootsschadensliste immer filtern, statt mit der Eingabe zu einem Zellwert sprinten
+        
+    }    
+    
+    
     private void iniValues(UUID boatId) {
         if (boatId != null) {
             this.filterFieldName  = BoatReservationRecord.BOATID;

--- a/de/nmichael/efa/gui/dataedit/BoatReservationItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/BoatReservationItemTypeDataRecordTable.java
@@ -1,0 +1,83 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+import de.nmichael.efa.data.BoatReservationRecord;
+
+public class BoatReservationItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public BoatReservationItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	// dies ist erforderlich für die Bootsreservierung - damit bei der Suche nach
+	// einem Datum
+	// auch Reservierungen gefunden werden, deren Zeitraum das eingegebene Datum
+	// abdeckt.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		//
+		if (filterValue == null) {
+			return false;
+
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		if (theDataRecord.getAsString(BoatReservationRecord.TYPE).equals(BoatReservationRecord.TYPE_ONETIME)) {
+
+			String theDateFrom = theDataRecord.getAsString(BoatReservationRecord.DATEFROM);
+			String theDateTo = theDataRecord.getAsString(BoatReservationRecord.DATETO);
+
+			if ((theDateFrom == null) || (theDateTo == null)) {
+				return false;
+			} else {
+
+				DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+				DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+				if ((fromDate.isSet() && toDate.isSet())) {
+
+					// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten der
+					// Reservierung ist
+
+					return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+				} else {
+					return false;
+				}
+			}
+
+		} else {
+			// weekly reservation -
+			// wir ermitteln den Wochentag aus dem eingegebenen Datum, und schauen, 
+			// ob es zu diesem Wochentag eine Reservierung gibt.
+			
+			String strWeekday = curDate.getWeekdayAsEfaType();
+			String strWeekdayFromRecord = theDataRecord.getAsString(BoatReservationRecord.DAYOFWEEK);
+			
+			return strWeekday.equals(strWeekdayFromRecord);
+			
+		}
+
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/SessionGroupItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/SessionGroupItemTypeDataRecordTable.java
@@ -1,0 +1,60 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.SessionGroupRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class SessionGroupItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+	public SessionGroupItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(SessionGroupRecord.STARTDATE);
+		String theDateTo = theDataRecord.getAsString(SessionGroupRecord.ENDDATE);
+
+		if ((theDateFrom == null) || (theDateTo == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+			if ((fromDate.isSet() && toDate.isSet())) {
+
+				// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+
+				return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+			} else {
+				return false;
+			}
+		}
+	}
+}

--- a/de/nmichael/efa/gui/dataedit/SessionGroupListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/SessionGroupListDialog.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 
 
 // @i18n complete
@@ -57,6 +58,9 @@ public class SessionGroupListDialog extends DataListDialog {
         iniValues(logbook, selectedSessionGroupId, true);
     }
 
+    
+    
+    
     private void iniValues(String logbook, UUID selectedSessionGroupId, boolean modeSelectSessionGroup) {
         this.logbook = logbook;
         this.selectedSessionGroupId = selectedSessionGroupId;
@@ -84,14 +88,73 @@ public class SessionGroupListDialog extends DataListDialog {
         intelligentColumnWidth = false;
     }
 
+    
+    // Methode übernommen von DataListDialog - Ausnahme ist, dass wir hier einen
+    // expliziten BoatReservationItemTypeDataRecordTable setzen, damit man besser filtern kann.
     protected void iniDialog() throws Exception {
-        super.iniDialog();
+        mainPanel.setLayout(new BorderLayout());
+        
+        JPanel mainTablePanel = new JPanel();
+        mainTablePanel.setLayout(new BorderLayout());
+
+        if (filterFieldDescription != null) {
+            JLabel filterName = new JLabel();
+            filterName.setText(filterFieldDescription);
+            filterName.setHorizontalAlignment(SwingConstants.CENTER);
+            mainTablePanel.add(filterName, BorderLayout.NORTH);
+            mainTablePanel.setBorder(new EmptyBorder(10,0,0,0));
+        }
+
+        table = new SessionGroupItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+        table.setSorting(sortByColumn, sortAscending);
+        table.setFontSize(tableFontSize);
+        table.setMarkedCellColor(markedCellColor);
+        table.setMarkedCellBold(markedCellBold);
+        table.disableIntelligentColumnWidth(!intelligentColumnWidth);
+        if (minColumnWidth > 0) {
+            table.setMinColumnWidth(minColumnWidth);
+        }
+        if (minColumnWidths != null) {
+            table.setMinColumnWidths(minColumnWidths);
+        }
+        table.setButtonPanelPosition(buttonPanelPosition);
+        table.setFieldSize(600, 500);
+        table.setPadding(0, 0, 10, 0);
+        table.displayOnGui(this, mainTablePanel, BorderLayout.CENTER);
+
+        boolean hasEditAction = false;
+        for (int i=0; actionType != null && i < actionType.length; i++) {
+            if (actionType[i] == ItemTypeDataRecordTable.ACTION_EDIT) {
+                hasEditAction = true;
+            }
+        }
+        if (!hasEditAction) {
+            table.setDefaultActionForDoubleclick(-1);
+        }
+
+        iniControlPanel();
+        mainPanel.add(mainTablePanel, BorderLayout.CENTER);
+
+        setRequestFocus(table);
+        this.validate();
+        
+        //uebernommen aus bisheriger iniDialog() Methode von SessionGroupListDialog
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setDefaultActionForDoubleclick(ACTION_SELECT);
         if (selectedSessionGroupId != null) {
             table.selectValue(selectedSessionGroupId.toString());
         }
-    }
+        
+        table.setIsFilterSet(true);// in der Fahrtgruppenliste immer filtern, statt mit der Eingabe zu einem Zellwert sprinten
+
+    }        
+    
 
     public void keyAction(ActionEvent evt) {
         _keyAction(evt);

--- a/de/nmichael/efa/gui/dataedit/StatisticsItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/StatisticsItemTypeDataRecordTable.java
@@ -1,0 +1,62 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.StatisticsRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class StatisticsItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public StatisticsItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(StatisticsRecord.DATEFROM);
+		String theDateTo = theDataRecord.getAsString(StatisticsRecord.DATETO);
+
+		if ((theDateFrom == null) || (theDateTo == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+			if ((fromDate.isSet() && toDate.isSet())) {
+
+				// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+
+				return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+			} else {
+				return false;
+			}
+		}
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
@@ -10,18 +10,29 @@
 
 package de.nmichael.efa.gui.dataedit;
 
-import de.nmichael.efa.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.util.UUID;
+
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+
+import de.nmichael.efa.Daten;
 import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemType;
 import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
-import de.nmichael.efa.data.*;
-import de.nmichael.efa.data.storage.*;
+import de.nmichael.efa.data.Statistics;
+import de.nmichael.efa.data.StatisticsRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
 import de.nmichael.efa.statistics.StatisticTask;
-import de.nmichael.efa.util.*;
 import de.nmichael.efa.util.Dialog;
-import java.util.*;
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import de.nmichael.efa.util.International;
 
 
 // @i18n complete
@@ -106,9 +117,64 @@ public class StatisticsListDialog extends DataListDialog {
         }
     }
 
+    
+         
     protected void iniDialog() throws Exception {
-        super.iniDialog();
+        mainPanel.setLayout(new BorderLayout());
+        
+        JPanel mainTablePanel = new JPanel();
+        mainTablePanel.setLayout(new BorderLayout());
+
+        if (filterFieldDescription != null) {
+            JLabel filterName = new JLabel();
+            filterName.setText(filterFieldDescription);
+            filterName.setHorizontalAlignment(SwingConstants.CENTER);
+            mainTablePanel.add(filterName, BorderLayout.NORTH);
+            mainTablePanel.setBorder(new EmptyBorder(10,0,0,0));
+        }
+
+        table = new StatisticsItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+        table.setSorting(sortByColumn, sortAscending);
+        table.setFontSize(tableFontSize);
+        table.setMarkedCellColor(markedCellColor);
+        table.setMarkedCellBold(markedCellBold);
+        table.disableIntelligentColumnWidth(!intelligentColumnWidth);
+        if (minColumnWidth > 0) {
+            table.setMinColumnWidth(minColumnWidth);
+        }
+        if (minColumnWidths != null) {
+            table.setMinColumnWidths(minColumnWidths);
+        }
+        table.setButtonPanelPosition(buttonPanelPosition);
+        table.setFieldSize(600, 500);
+        table.setPadding(0, 0, 10, 0);
+        table.displayOnGui(this, mainTablePanel, BorderLayout.CENTER);
+
+        boolean hasEditAction = false;
+        for (int i=0; actionType != null && i < actionType.length; i++) {
+            if (actionType[i] == ItemTypeDataRecordTable.ACTION_EDIT) {
+                hasEditAction = true;
+            }
+        }
+        if (!hasEditAction) {
+            table.setDefaultActionForDoubleclick(-1);
+        }
+
+        iniControlPanel();
+        mainPanel.add(mainTablePanel, BorderLayout.CENTER);
+
+        setRequestFocus(table);
+        this.validate();
+    	
+        //übernommen aus der ursprünglichen iniDialog() Methode.
         table.setDefaultActionForDoubleclick(ACTION_CREATESTATISTICS);
+        table.setIsFilterSet(true);
         if (admin == null) {
             table.setVisibleSearchPanel(false);
         }


### PR DESCRIPTION
The following changes have been made to
   BoatDamageList, BoatReservationList, SessionGroupList, StatisticsRecordLIst
- the filter checkbox is checked when the dialog is shown.
- when you enter a date, and the filter checkbox is checked, any entry is found where the filtered date is between the start and the end date of the entry (which are displayed within the table)

Within the boat reservation list an additional feature has been added:
- if you provide a date in the filter text field, also the weekly reservations are found which apply to the date criterion in the filter text field.