### PR TITLE
More whitespace between cell content and cell border

### DIFF
--- a/de/nmichael/efa/gui/util/Table.java
+++ b/de/nmichael/efa/gui/util/Table.java
@@ -43,6 +43,12 @@ public class Table extends JTable {
         this.header = header;
         this.data = data;
 
+        // SGB Update for standard tables: increase row height for better readability
+        Font f = this.getFont();
+        FontMetrics fm = this.getFontMetrics(f);
+        this.setRowHeight(fm.getHeight()+4);
+
+        
         if (renderer == null) {
             renderer = new TableCellRenderer();
         }

--- a/de/nmichael/efa/gui/util/TableCellRenderer.java
+++ b/de/nmichael/efa/gui/util/TableCellRenderer.java
@@ -36,6 +36,12 @@ public class TableCellRenderer extends DefaultTableCellRenderer {
             boolean isMarked = value instanceof TableItem && ((TableItem)value).isMarked();
             boolean isDisabled = value instanceof TableItem && ((TableItem)value).isDisabled();
             String txt = value.toString();
+            
+            //SGB Update for standard tables: indent cell content for better readability
+            if (c instanceof JComponent) {
+      	 		((JComponent) c).setBorder(BorderFactory.createEmptyBorder(0,6,0,6));
+       	 	}
+            
             if (isMarked && markedBold) {
                 c.setFont(c.getFont().deriveFont(Font.BOLD));
             }


### PR DESCRIPTION
The row height is 4 pix higher than the actual font height --> so two pix on top and below the actual text within the cell.

The cell renderer leaves 6pix space on the left and right side of the cell content.

Both changes lead to much better readability of table contents.