### PR TITLE
Alternating color for tables, inverted cursor

### DIFF
--- a/de/nmichael/efa/gui/util/Table.java
+++ b/de/nmichael/efa/gui/util/Table.java
@@ -43,6 +43,10 @@ public class Table extends JTable {
         this.header = header;
         this.data = data;
 
+        // SGB Update for standard tables: Update for standard inverted cursor
+        this.setSelectionBackground(new Color(75,134,193));
+        this.setSelectionForeground(Color.WHITE);
+        
         if (renderer == null) {
             renderer = new TableCellRenderer();
         }

--- a/de/nmichael/efa/gui/util/TableCellRenderer.java
+++ b/de/nmichael/efa/gui/util/TableCellRenderer.java
@@ -36,13 +36,22 @@ public class TableCellRenderer extends DefaultTableCellRenderer {
             boolean isMarked = value instanceof TableItem && ((TableItem)value).isMarked();
             boolean isDisabled = value instanceof TableItem && ((TableItem)value).isDisabled();
             String txt = value.toString();
+            
             if (isMarked && markedBold) {
                 c.setFont(c.getFont().deriveFont(Font.BOLD));
             }
             Color bkgColor = Color.white;
             Color fgColor = Color.black;
+            
+            //SGB Update for standard tables: alternating row color
+            Color alternateColor = new Color(219,234,249);
+            bkgColor = (row % 2 == 0 ? alternateColor : Color.white);
+            
             if (isSelected) {
                 bkgColor = table.getSelectionBackground();
+                // SGB Update for standard tables: when selected, we should always use the selection foreground.
+                fgColor= table.getSelectionForeground();
+                
             } else {
                 if (isDisabled && disabledBkgColor != null) {
                     bkgColor = disabledBkgColor;
@@ -51,12 +60,23 @@ public class TableCellRenderer extends DefaultTableCellRenderer {
                     bkgColor = markedBkgColor;
                 }
             }
-            if (isDisabled && disabledFgColor != null) {
-                fgColor = disabledFgColor;
+            if (!isSelected && isDisabled && disabledFgColor != null) {
+                fgColor = disabledFgColor; // disabled color to be used only when col is not selected.
             }
+            
             if (isMarked && markedFgColor != null) {
                 fgColor = markedFgColor;
+            	if (isSelected) {
+                    // SGB Update for standard tables: when selected, we should always use the selection foreground.
+                    // Marked FG color is red by default, and does not work well with blue as alternating line color.
+
+            		fgColor = table.getSelectionForeground(); 
+            	}
+            	else {
+            		fgColor = markedFgColor;
+            	}
             }
+            
             if (fontSize > 0) {
                 c.setFont(c.getFont().deriveFont((float)fontSize));
                 c.setFont(c.getFont().deriveFont(Font.BOLD));


### PR DESCRIPTION
All tables have alternating row colors (pastel blue, white).

The selection color of the current cell is a dark blue and white text.

When a row is selected, text color is always white - so the disabled text colors and highlighted text colors (red) will only be applied on rows which are not selected.